### PR TITLE
added missing import sys

### DIFF
--- a/esm_environment/esm_environment.py
+++ b/esm_environment/esm_environment.py
@@ -7,6 +7,7 @@ import copy
 import os
 import warnings
 import re
+import sys
 
 import esm_parser
 from esm_rcfile import FUNCTION_PATH


### PR DESCRIPTION
Mini bugfix. Import to sys was missing at top. I noticed that while trying to replicate the error that @seb-wahl issued at https://github.com/esm-tools/esm_parser/issues/41

I know `develop` is not the right place for the hotfix but I can also add that separately to `release` as well.

error log:
```python
...
  File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_environment/esm_environment/esm_environment.py", line 78, in __init__
    self.general_environment(complete_config, run_or_compile)
  File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_environment/esm_environment/esm_environment.py", line 352, in general_environment
    self.load_component_env_changes_only_in_setup(complete_config)
  File "/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_environment/esm_environment/esm_environment.py", line 389, in load_component_env_changes_only_in_setup
    sys.exit(1)
NameError: name 'sys' is not defined
```