### PR TITLE
unset_vars option added to the environment

### DIFF
--- a/esm_environment/__init__.py
+++ b/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 from .esm_environment import *

--- a/esm_environment/esm_environment.py
+++ b/esm_environment/esm_environment.py
@@ -71,7 +71,7 @@ class EnvironmentInfos:
             )
 
         # Add_s can only be inside choose_ blocks in the machine file
-        for entry in ["add_module_actions", "add_export_vars"]:
+        for entry in ["add_module_actions", "add_export_vars", "add_unset_vars"]:
             if entry in self.config:
                 del self.config[entry]
 
@@ -164,10 +164,10 @@ class EnvironmentInfos:
                 modelconfig["environment_changes"] = modelconfig[thesechanges]
 
         if "environment_changes" in modelconfig:
-            for entry in ["add_module_actions", "add_export_vars"]:
+            for entry in ["add_module_actions", "add_export_vars", "add_unset_vars"]:
                 # Initialize the environment variables
                 if not entry in self.config:
-                    if entry == "add_module_actions":
+                    if entry in ["add_module_actions", "add_unset_vars"]:
                         self.config[entry] = []
                     elif entry == "add_export_vars":
                         self.config[entry] = {}
@@ -193,7 +193,7 @@ class EnvironmentInfos:
             esm_parser.basic_choose_blocks(self.config, self.config)
 
             # Remove the environment variables from the config
-            for entry in ["add_module_actions", "add_export_vars"]:
+            for entry in ["add_module_actions", "add_export_vars", "add_unset_vars"]:
                 if entry in self.config:
                     del self.config[entry]
 
@@ -529,6 +529,10 @@ class EnvironmentInfos:
                 # defined now as dictionaries
                 else:
                     environment.append("export {str(var)}")
+        environment.append("")
+        if "unset_vars" in self.config:
+            for var in self.config["unset_vars"]:
+                environment.append(f"unset {var}")
 
         return environment
 

--- a/esm_environment/esm_environment.py
+++ b/esm_environment/esm_environment.py
@@ -485,6 +485,7 @@ class EnvironmentInfos:
         """
 
         environment = []
+        # Write module actions
         if "module_actions" in self.config:
             for action in self.config["module_actions"]:
                 # seb-wahl: workaround to allow source ... to be added to the batch header
@@ -530,6 +531,7 @@ class EnvironmentInfos:
                 else:
                     environment.append("export {str(var)}")
         environment.append("")
+        # Write the unset commands
         if "unset_vars" in self.config:
             for var in self.config["unset_vars"]:
                 environment.append(f"unset {var}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_environment",
-    version="5.1.0",
+    version="5.1.1",
     zip_safe=False,
 )


### PR DESCRIPTION
Allows for defining a list of vars that can be `unset`. This is an important feature for running AWICM3 with heterogeneous parallelization in `JUWELS` (AWI-CM3/project_management#53), where resubmission is not possible due to problems with the SLURM defaults. `unset` allows us to remove the problematic SLURM variables.

