### PR TITLE
hotfix/indented choose with variable in computer

### DIFF
--- a/esm_environment/__init__.py
+++ b/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.2"
+__version__ = "5.1.3"
 
 from .esm_environment import *

--- a/esm_environment/esm_environment.py
+++ b/esm_environment/esm_environment.py
@@ -182,12 +182,7 @@ class EnvironmentInfos:
             # Merge the ``environment_changes`` into the general ``config``
             self.config.update(modelconfig["environment_changes"])
             # Change any ``choose_computer.*`` block in ``config`` to ``choose_*``
-            all_keys = list(self.config.keys())
-            for key in all_keys:
-                if "choose_computer." in key:
-                    newkey = key.replace("computer.", "")
-                    self.config[newkey] = self.config[key]
-                    del self.config[key]
+            self.remove_computer_from_choose(self.config)
 
             # Resolve ``choose_`` blocks
             esm_parser.basic_choose_blocks(self.config, self.config)
@@ -568,6 +563,26 @@ class EnvironmentInfos:
             for command in self.commands:
                 script_file.write(f"{command}\n")
             script_file.write("\n")
+
+
+    def remove_computer_from_choose(self, config):
+        """
+        Recursively remove ``computer.`` from all the `choose_` keys.
+
+        Parameters
+        ----------
+        config : dict
+            Configuration to search for ``choose_computer.`` blocks.
+        """
+        all_keys = list(config.keys())
+        for key in all_keys:
+            if isinstance(key, str) and "choose_computer." in key:
+                newkey = key.replace("computer.", "")
+                config[newkey] = config[key]
+                del config[key]
+                key = newkey
+            if isinstance(config[key], dict):
+                self.remove_computer_from_choose(config[key])
 
 
     @staticmethod

--- a/esm_environment/esm_environment.py
+++ b/esm_environment/esm_environment.py
@@ -565,24 +565,24 @@ class EnvironmentInfos:
             script_file.write("\n")
 
 
-    def remove_computer_from_choose(self, config):
+    def remove_computer_from_choose(self, chapter):
         """
         Recursively remove ``computer.`` from all the `choose_` keys.
 
         Parameters
         ----------
-        config : dict
-            Configuration to search for ``choose_computer.`` blocks.
+        chapter : dict
+            Dictionary to search for ``choose_computer.`` blocks.
         """
-        all_keys = list(config.keys())
+        all_keys = list(chapter.keys())
         for key in all_keys:
             if isinstance(key, str) and "choose_computer." in key:
                 newkey = key.replace("computer.", "")
-                config[newkey] = config[key]
-                del config[key]
+                chapter[newkey] = chapter[key]
+                del chapter[key]
                 key = newkey
-            if isinstance(config[key], dict):
-                self.remove_computer_from_choose(config[key])
+            if isinstance(chapter[key], dict):
+                self.remove_computer_from_choose(chapter[key])
 
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.2
+current_version = 5.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dbarbi/esm_environment",
-    version="5.1.2",
+    version="5.1.3",
     zip_safe=False,
 )


### PR DESCRIPTION
Removes recursively the string `computer.` from `choose_computer.<variable>` of the environment dictionaries. 

This was necessary on the first place because the config available for the solution of the chooses is already the one in `computer` and not the whole config. The old lines used to remove computer from the first level `choose_` (i.e. `choose_computer.name`):
```
environment_changes:
    choose_computer.name:
        mistral:
             choose_computer.useMPI:
                  intelmpi:
                      [ ... ]
```
but not from the nested `choose_` (i.e. `choose_computer.intelMPI`).

This hotfix solves this issue.

**TODO**

- [x] Test esm_master
- [x] Test esm_runscripts